### PR TITLE
Increase AJAX timeout

### DIFF
--- a/src/rdfauthor.js
+++ b/src/rdfauthor.js
@@ -1915,7 +1915,7 @@ RDFauthor = (function($) {
             
             /* Default ajax options (JSON) */
             var ajaxOptions = {
-                timeout: 2000, 
+                timeout: 10000,
                 dataType: 'json', 
                 url: serviceURI, 
                 data: parameters, 


### PR DESCRIPTION
This pull request increases the timeout for AJAX calls from 2 to 10 seconds.

When using RDFauthor to create instances I noticed a lot of aborted AJAX calls, which was related to the timeout of 2 seconds.
Considering the number of AJAX requests that are triggered by RDFauthor, the timeout of 2 seconds seems to be to low to answer all of them, so I raised it up to 10 seconds (5 seconds were not enough on my machine).

There might be better solutions (for example combining some of the requests), but for now this seems to be the easiest solution.
